### PR TITLE
Adding a link to github repo

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,6 +26,7 @@
           <li><a href="/atom.xml">Atom Feed</a></li>
           <li><a href="https://plus.google.com/116336973990953325499" rel="publisher">Google+</a></li>
           <li><a href="http://twitter.com/designopen">Twitter</a></li>
+          <li><a href="https://github.com/opensourcedesignis/opensourcedesignis.github.io">Github Repo</a></li>
         </ul>
       </nav>
     </footer>


### PR DESCRIPTION
Sometimes I find myself visiting opensourcedesign.is just to find the repo (not just issues). So this code is adding that link. Yay/nay?
