### PR TITLE
Open Design != Design by Committee

### DIFF
--- a/blogging_about/_posts/2013-10-31-open-design-is-not-design-by-committee.md
+++ b/blogging_about/_posts/2013-10-31-open-design-is-not-design-by-committee.md
@@ -1,0 +1,36 @@
+---
+title: "Open Design is not Design by Committee"
+layout: post
+category: blogging_about
+tags: faq
+author: garthdb
+priority: 0.9
+---
+
+As I've chatted with designers about the idea of working in the open and allowing for community contributions, eventually someone says something to the effect of "that sounds a lot like design by committee." I have to admit, there are some similarities between the two design environments, but the differences are significant.
+
+For those who are unfamiliar with the term Design By Committee, it is a special kind of hell for designers who find themselves working on a project with too many stakeholders. Often times this causes a project to pivot in seemingly random directions as committee members compromise on divergent opinions.
+
+##Misunderstanding of the Term Open Source
+
+I think some designers have the mistaken idea that open source projects are lawless anarchies, where random contributors haphazardly throw bits and pieces together; forming a version of Frankenstein's monster that hopefully came perform basic tasks. In reality a healthy open source project needs to have an owner, or small group of owners[^1], with a strong sense of where the project is heading. With a core team in place, outside contributors can file issues, submit contributions, and just complain about things they don't like. The core team of owners can then accept or reject the contributions from the community (hopefully in a way that encourages growth and future contributions).
+
+##Ownership is key
+
+The most important difference between Open Source Design and Design by Committee is this concept of ownership. In the context of Design by Committee, usually the designer is a contractor or agency hired by the committee, or underling that is far below the committee members on the org chart. This is the heart of the problem with designing by committee; instead of being an expert consultant, the designer becomes the tool of the committee members who often have very little design experience. It is not unlike giving a formula one racecar to someone without a driver's license; regardless of how well the car can perform, the result will most likely be unremarkable or even disastrous.
+
+In the case of Open Source Design, not all contributors and community members are equal, but all involved should be designers. The owner of the project is the lead designer the majority of the time, and when contributions come in, switches to role of creative director. They should help to shape contributions to fit into the overall purpose of the project, or reject them outright with clear reasoning.
+
+##That Sounds Like a Lot of Work
+
+I can't lie and say that it isn't, but community contributions, in the form of issues filed or pull requests submitted, are just another form of design criticism, and criticism is an essential part of any design process. It is possible that the owner will have to deal with more feedback than expected, but this collision of ideas will open opportunities for real innovation. It is also important to know that anytime the discussion is moving past the point of useful collaboration, the owner should not hesitate to shut it down and get back to work.
+
+##What Happens if the Project Owner is a Tool?
+
+It can happen. As ideas collide in a discussion, it is possible that contributors will feel the need to move in a different direction than the owner's goals. In an open source project with the right kind of license, the rebelling faction should have the option of forking the project and continuing independently. This is not a great outcome in terms of community development, but it gives an owner with dictatorial tendencies a reason to work with others.
+
+##Why do it?
+
+When implemented correctly, the Open Source workflow benefits all parties involved. Contributors get a chance to collaborate with designers in a more autonomous capacity than most work environments allow, and still receive feedback and encouragement from the project owners. The owners get outside opinions to challenge their assumptions and sometimes they get fantastic contributions worth all the hassle. Most importantly, all the designers involved have the privilege of improving the design community and building something they care about.
+
+[^1]:Eric S. Raymond has an [excellent article](http://catb.org/esr/writings/homesteading/homesteading/ar01s04.html) on the subject of Open Source Ownership.


### PR DESCRIPTION
This is a common reply to my bringing up the idea of open source design.  It usually goes something like - "so everyone one is going to make design decisions? Nothing would get done.  It's better to do it by myself"

True - some projects shouldn't get input, just finish them
True - not all feedback will be useful
True - design by committee sucks

But! this is design by design committee, and where the designer is the owner.  The design by committee is lame because the committee is the group running it, and they don't always have the best design experience to base decisions on.  So the designers spends his/her time educating them and winning them over.

That still needs to happen when designing in the open, but not completely - the designer is the product owner, and chooses the feedback to utilize, no one can take over the project (though they could fork it if it was open source).
