### PR TITLE
Incorrect display of fonts on Windows 8 (tested Firefox and Chrome)

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -5,6 +5,9 @@ body {
   font-size: 1rem;
   font-weight: 300;
 }
+h1, h2, h3, h4, h5, h6 {
+  font-weight: bold;
+}
 .site {
   max-width: 600px;
   margin: 0 auto;


### PR DESCRIPTION
Normal weight looks a bit unpleasing when viewed on Firefox 25 and Chrome 30 (Windows 8). Maybe it's better to use Light weight for body instead?

![comparison of regular and light weights of source sans pro](https://f.cloud.github.com/assets/389387/1681229/62eefaf0-5d8f-11e3-8aa5-a70210b8f6b3.png)
(make sure to open above image in separate tab/window, downscaling somewhat hinders the quality)

Also, maybe it's wise to look into typefaces from the [League of Movable Type](https://www.theleagueofmoveabletype.com/) for headings to introduce some contrast? All their fonts are open-sourced, they have [repository on GitHub](https://github.com/theleagueof).
