### PR TITLE
Add more whitespace around content and footer

### DIFF
--- a/_sass/_footer.scss
+++ b/_sass/_footer.scss
@@ -2,7 +2,7 @@
 
 #globalfoot{
   background: #000;
-  padding: .5rem 0;
+  padding: 2rem 0;
   text-align: center;
   width: 100%;
   ul{

--- a/_sass/_todo.scss
+++ b/_sass/_todo.scss
@@ -54,15 +54,15 @@ a {
   text-decoration: none;
 }
 code{
-  font-size: 80%; 
+  font-size: 80%;
 }
 blockquote{
   font-style: italic;
   padding: .5rem 1rem .75rem;
   margin: 1rem 0 1rem;
   line-height: 1.2;
-  font-weight: 600; 
-  max-width: 80%; 
+  font-weight: 600;
+  max-width: 80%;
 }
 blockquote p{
    margin: 0;
@@ -150,6 +150,10 @@ article ol li::before{
   margin-right: 1rem;
   width: 6rem;
   height: 6rem;
+}
+
+.site {
+  padding: 2rem 0;
 }
 
 // Media Queries for Text Size Changes


### PR DESCRIPTION
Previously the footer was a bit too tightly "packed"

Screenshots of new changes:

#### A bit more white space above **About**
![screenshot 2015-01-31 11 34 46](https://cloud.githubusercontent.com/assets/1232405/5989442/300e4a64-a93d-11e4-9ca6-d3ca1d0332d8.png)

#### Footer
![screenshot 2015-01-31 11 31 52](https://cloud.githubusercontent.com/assets/1232405/5989428/ce1ba5ae-a93c-11e4-915f-14ee4969f218.png)
