### PR TITLE
Fix bug with disqus

### DIFF
--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -1,7 +1,7 @@
 <div id="disqus_thread"></div>
 <script type="text/javascript">
   /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
-  var disqus_shortname = 'opensourcedesignis'; // required: replace example with your forum shortname
+  var disqus_shortname = 'opensourcedesignis';
   {% if page.title %}
   var disqus_title = "{{ page.title }}";
   {% endif %}


### PR DESCRIPTION
Single-line JavaScript comment causes subsequent lines to be treated as comments when line breaks are stripped by minification process.