### PR TITLE
Tweak the HTML compression

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,6 +8,11 @@ exclude: [vendor]
 sass:
   sass_dir: _sass
   style: compressed
+# _layouts/compress.html
+compress_html:
+  clippings: all
+  endings: all
+  comments: ["<!--", "-->"]
 post:
   template: _post.txt
   extension: md


### PR DESCRIPTION
This removes optional end tags, comments, and whitespace around block elements.