### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/designopen/designopen.github.io.png?label=ready&title=Ready)](https://waffle.io/designopen/designopen.github.io)
 # [Design Open](http://designopen.org) [![Travis Badge](https://travis-ci.org/DesignOpen/designopen.github.io.svg)](https://travis-ci.org/DesignOpen/designopen.github.io)
 
 [![Join the chat at https://gitter.im/DesignOpen/designopen.github.io](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/DesignOpen/OpenSourceDesign?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/designopen/designopen.github.io

This was requested by a real person (user GarthDB) on waffle.io, we're not trying to spam you.