### PR TITLE
Add categories.json

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -1,0 +1,3 @@
+---
+---
+{"categories":[{% for categ in site.resourceCategories %}"{{ categ }}"{% if forloop.last == false %},{% endif %}{% endfor %}]}


### PR DESCRIPTION
Add categories.json for the Resource Collector Chrome Extension.

Currently, the Chrome Extension transforms the JSONP into JSON before parsing it.

```javascript
// Transform JSONP into JSON
resp = resp.replace(/^\s*functionCall\(\s*/, '{ "categories":')
           .replace(/\s*\);\s*$/,'}')
           .replace(/,\s*\]/g, "]")
           .replace(/\n/g, "");
```

This new file generates the following JSON so that the parsing is not required:
```json
{"categories":["philosophy","sources","redesigns","inspiration","tutorials"]}
```