### PR TITLE
Add readability improvements

### DIFF
--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -38,9 +38,18 @@
 .article-body,
 .article-footer,
 .resource-comments{
-  max-width: 800px;
+  max-width: 530px;
   box-sizing: border-box;
   margin: 0 auto;
   padding-right: 20px;
   padding-left: 20px;
+}
+
+@media screen and (min-width: 50em) {
+  .home-section,
+  .page-section,
+  .article-header,
+  .article-body,
+  .article-footer,
+  .resource-comments { max-width: 640px; }
 }


### PR DESCRIPTION
-> Reduce max-width of the main sectioning elements to get a more comfortable measure (line-length).

A measure between 45 and 75 (others say 60 and 90) chars per line are considered as a comfortable length to read. I've adjusted the main sectioning elements to get there (text marked red).
smaller view:
![small-view](https://cloud.githubusercontent.com/assets/1640079/6800554/e16eddae-d21f-11e4-89ce-2990ead19b7d.png)

larger view:
![large-view](https://cloud.githubusercontent.com/assets/1640079/6800574/0fe358cc-d220-11e4-8147-9ec84f17f49c.png)
