### PR TITLE
Add resource: The Open Design Review as a tool to establish a company-wide design culture

### DIFF
--- a/resources/_posts/2015-03-25-the-open-design-review-as-a-tool-to-establish-a-company-wide-design-culture.md
+++ b/resources/_posts/2015-03-25-the-open-design-review-as-a-tool-to-establish-a-company-wide-design-culture.md
@@ -1,0 +1,9 @@
+---
+title: "The Open Design Review as a tool to establish a company-wide design culture"
+layout: resource
+source_url: "http://www.benedikt-lehnert.de/blog/open-design-reviews-as-a-tool-to-establish-a-company-wide-design-culture"
+category: "philosophy"
+contributor: "dam"
+posted_date: "2015-03-25"
+---
+Benedikt Lehnert discusses using open design reviews as a communication tool in an organization.

--- a/resources/_posts/2015-03-25-the-open-design-review-as-a-tool-to-establish-a-company-wide-design-culture.md
+++ b/resources/_posts/2015-03-25-the-open-design-review-as-a-tool-to-establish-a-company-wide-design-culture.md
@@ -6,4 +6,4 @@ category: "philosophy"
 contributor: "dam"
 posted_date: "2015-03-25"
 ---
-Benedikt Lehnert discusses using open design reviews as a communication tool in an organization.
+[Benedikt Lehnert](http://twitter.com/blehnert) discusses using open design reviews as a communication tool in an organization.


### PR DESCRIPTION
**URL:** http://www.benedikt-lehnert.de/blog/open-design-reviews-as-a-tool-to-establish-a-company-wide-design-culture
**Category:** philosophy
**Submitted by:** [@dam](http://twitter.com/dam)

**Description:** 
Benedikt Lehnert discusses using open design reviews as a communication tool in an organization.