### PR TITLE
Add resource: Richard Stallman’s GNU Manifesto Turns Thirty

### DIFF
--- a/resources/_posts/2015-03-30-richard-stallmans-gnu-manifesto-turns-thirty.md
+++ b/resources/_posts/2015-03-30-richard-stallmans-gnu-manifesto-turns-thirty.md
@@ -1,0 +1,9 @@
+---
+title: "Richard Stallman’s GNU Manifesto Turns Thirty"
+layout: resource
+source_url: "http://www.newyorker.com/business/currency/the-gnu-manifesto-turns-thirty"
+category: "philosophy"
+contributor: "garthdb"
+posted_date: "2015-03-30"
+---
+A key foundation to Free and Open Source Software turns 30.


### PR DESCRIPTION
**URL:** http://www.newyorker.com/business/currency/the-gnu-manifesto-turns-thirty
**Category:** philosophy
**Submitted by:** [@garthdb](http://twitter.com/garthdb)

**Description:** 
A key foundation to Free and Open Source Software turns 30.