### PR TITLE
Fix links that caused build errors

### DIFF
--- a/resources/_posts/2013-09-25-css-tricks-redesign-kickstarter.md
+++ b/resources/_posts/2013-09-25-css-tricks-redesign-kickstarter.md
@@ -6,4 +6,4 @@ category: redesigns
 contributor: brad_frost
 posted_date: 2012-06-18
 ---
-[Chris Coyier](https://twitter.com/chriscoyier) used a [Kickstarter Project](http://www.kickstarter.com/projects/chriscoyier/screencasting-a-complete-redesign) to fund a redesign of CSS-Tricks. He is [screencasting](http://css-tricks.com/screencasting-complete-redesign-get-access-kickstarter/) the process.
+[Chris Coyier](https://twitter.com/chriscoyier) used a [Kickstarter Project](https://www.kickstarter.com/projects/chriscoyier/screencasting-a-complete-redesign) to fund a redesign of CSS-Tricks. He is [screencasting](https://css-tricks.com/screencasting-complete-redesign-get-access-kickstarter/) the process.


### PR DESCRIPTION
Fixes Travid-CI build error caused by 301 redirect:

    External link http://css-tricks.com/screencasting-complete-redesign-get-access-kickstarter/ failed: 301 Peer certificate cannot be authenticated with given CA certificates