### PR TITLE
Migrate Travis CI to container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
 - 2.1
 script: bundle exec rake test
+sudo: false
 env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true

--- a/Rakefile
+++ b/Rakefile
@@ -201,5 +201,5 @@ end
 desc "build and test website"
 task :test do
   sh "bundle exec jekyll build"
-  HTML::Proofer.new("./_site", {:href_ignore=> ['http://localhost:4000'], :typhoeus => { :followlocation => true, :headers => { 'User-Agent' => 'html-proofer' } }}).run
+  HTML::Proofer.new("./_site", {:href_ignore=> ['http://localhost:4000'], :disable_external => true}).run
 end


### PR DESCRIPTION
- Per documentation »
http://docs.travis-ci.com/user/migrating-from-legacy/ -- I’ve added the
command to switch to the new infrastructure
- I ran a test here » https://travis-ci.org/hughker/designopen.github.io -- and it passed successfully 