### PR TITLE
moved the site name to be secondary to the page title

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-name: Open Design Foundation
+name: The Open Design Foundation
 description: We think the best way to improve the design industry is to work in the open.
 url: http://opendesign.foundation
 permalink: /:categories/:title/

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -18,7 +18,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="initial-scale=1.0" />
-  <title>Open Design Foundation{% if page.title %} | {{ page.title }}{% endif %}</title>
+  <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.name }}</title>
   <meta name="description" content="{{ pagedescription }}">
 
   <meta name="twitter:card" content="summary">

--- a/_layouts/facebook-academy.html
+++ b/_layouts/facebook-academy.html
@@ -7,7 +7,7 @@ layout: compress
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{% if page.title %}{{ page.title }} | {% endif %}The Open Design Foundation</title>
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.name }}</title>
     <link rel="shortcut icon" href="/favicon.ico">
     <style>
       .guys{

--- a/_layouts/open-design-is-not-design-by-committee.html
+++ b/_layouts/open-design-is-not-design-by-committee.html
@@ -7,7 +7,7 @@ layout: compress
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{% if page.title %}{{ page.title }} | {% endif %}The Open Design Foundation</title>
+  <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.name }}</title>
   <link rel="shortcut icon" href="/favicon.ico">
   <style>
     @import url(https://fonts.googleapis.com/css?family=Open+Sans:400,800);

--- a/_layouts/using-github-for-design-collaboration.html
+++ b/_layouts/using-github-for-design-collaboration.html
@@ -7,7 +7,7 @@ layout: compress
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{% if page.title %}{{ page.title }} | {% endif %}The Open Design Foundation</title>
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.name }}</title>
     <link rel="shortcut icon" href="/favicon.ico">
     <style>
       #sitebar{background:#000;padding-top:5px;height:36px;text-align:center;-moz-box-sizing:border-box;box-sizing:border-box;position:fixed;width:100%;top:0;z-index:10;}

--- a/index.html
+++ b/index.html
@@ -1,6 +1,5 @@
 ---
 layout: home
-title: Home
 permalink: /
 ---
 <div id="content" class="site" >


### PR DESCRIPTION
#### Purpose

Current the title of the site/organization is shown first in the `<title>`. When you have a bunch of tabs open (which I usually do) the title is cut off so it is hard to tell what page it is on.

#### Todos

- [x] Check tests and lint
- [x] Check it can merge with master

#### Relevant Issues/Pull Requests

#### Screenshots

Before:
![image](https://cloud.githubusercontent.com/assets/125516/14938046/55c44606-0ed5-11e6-80a5-9c20c8075f56.png)

After:
![image](https://cloud.githubusercontent.com/assets/125516/14938053/bd2a7a4a-0ed5-11e6-8378-5c55da10ce6f.png)

